### PR TITLE
replace regexps with xpaths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ const activeMinis = xpath(
   .map((s) => s.replace(/option value="([0-9]+)"(.*?)>/g, "").replace(/<\/option/g, ""));
 const activeMinisSorted = xpath(
   visitUrl("peevpee.php?place=rules"),
-  "//tr[@class='small']/td[@nowrap='']/text()"
+  "//tr[@class='small']/td[@nowrap]/text()"
 );
 const pvpIDs = Array.from(Array(activeMinis.length).keys());
 const sortedPvpIDs = activeMinis.map((mini) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,27 +8,22 @@ import {
   todayToString,
   use,
   visitUrl,
+  xpath,
 } from "kolmafia";
 import { $item, get, maxBy, set, sumNumbers } from "libram";
 
 // The fight page does not sort the minis by alphabetical order
 // So we have to reorder them to the rules page
-const activeMinis =
-  visitUrl("peevpee.php?place=fight")
-    .match(RegExp(/option value="\d+"(.*?)>(.*?)<\/option/g))
-    ?.splice(3)
-    .map((s) => s.replace(/option value="([0-9]+)"(.*?)>/g, "").replace(/<\/option/g, "")) ?? [];
-const activeMinisSorted =
-  visitUrl("peevpee.php?place=rules")
-    .match(RegExp(/nowrap><b>(.*?)\\*?<\/b>/g))
-    ?.map((s) =>
-      s
-        .replace("nowrap>", "")
-        .replace("*", "")
-        .replace("arrr", "ar")
-        .replace("<b>", "")
-        .replace("</b>", "")
-    ) ?? [];
+const activeMinis = xpath(
+  visitUrl("peevpee.php?place=fight"),
+  "//select[@name='stance']/option/text()"
+)
+  .splice(3)
+  .map((s) => s.replace(/option value="([0-9]+)"(.*?)>/g, "").replace(/<\/option/g, ""));
+const activeMinisSorted = xpath(
+  visitUrl("peevpee.php?place=rules"),
+  "//tr[@class='small']/td[@nowrap='']/text()"
+);
 const pvpIDs = Array.from(Array(activeMinis.length).keys());
 const sortedPvpIDs = activeMinis.map((mini) =>
   activeMinisSorted.findIndex((sortedMini) => sortedMini === mini)


### PR DESCRIPTION
I'm not 100% sure that this does what you're looking for, but here's a return for the first and second xpaths in mafia right now:
```
> js xpath( visitUrl("peevpee.php?place=fight"), "//select[@name='stance']/option/text()" )

Returned: aggregate string [13]
0 => Letter of the Moment
1 => Fashion Show
2 => Sooooper Sneaky
3 => Purity
4 => Hah, It's a Mystery!
5 => The Egg Hunt
6 => Hold Your Nose
7 => Innuendo Master
8 => Trophy Stacking Match
9 => Nog Lover (AGAIN!?!?)
10 => Microbrew and You
11 => Whatever, Here's a 13th Mini
12 => Wine Tasting Contest
```
```
> js xpath( visitUrl("peevpee.php?place=rules"), "//tr[@class='small']/td[@nowrap]/text()" )

Returned: aggregate string [13]
0 => Fashion Show
1 => Hah, It's a Mystery!
2 => Hold Your Nose
3 => Innuendo Master
4 => Letter of the Moment
5 => Microbrew and You*
6 => Nog Lover (AGAIN!?!?)*
7 => Purity
8 => Sooooper Sneaky
9 => The Egg Hunt
10 => Trophy Stacking Match
11 => Whatever, Here's a 13th Mini
12 => Wine Tasting Contest
```

imo xpaths are more legible and maintainable but ymmv