### PR TITLE
Fix UberPvPOptimizer dependency

### DIFF
--- a/KoLmafia/dependencies.txt
+++ b/KoLmafia/dependencies.txt
@@ -1,1 +1,1 @@
-github https://github.com/loathers/UberPvPOptimizer
+github loathers/UberPvPOptimizer


### PR DESCRIPTION
the full url here makes mafia try to clone "https://github.com/https://github.com/loathers/UberPvPOptimizer.git"