### PR TITLE
Addresses issues raised in #8

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -65,11 +65,12 @@ export function initializeSortedPvpIDs(): void {
 
 export const verbose = !get("PVP_MAB_reduced_verbosity", false);
 
-export function getFightRecords(): number[][] {
+// We add 7 to wins & losses for math reasons, as mentioned here: https://github.com/Pantocyclus/PVP_MAB/issues/8#issuecomment-4013324340
+export function getMutatedFightRecords(): number[][] {
   return pvpIDs.map((i) => {
     const wins = get(`myCurrentPVPWins_${i}`, 0);
     const losses = get(`myCurrentPVPLosses_${i}`, 0);
-    return [wins, losses];
+    return [wins + 7, losses + 7];
   });
 }
 
@@ -135,10 +136,10 @@ export function updateSeason(): void {
     throw new Error("We cannot update the season until you've broken your stone!");
   if (pvpIDs.length === 0) throw new Error("There are current no valid PVP minis!");
 
-  // Reset wins and losses (pad all at 7 wins 7 losses [prime numbers good])
+  // Reset wins and losses
   pvpIDs.forEach((i) => {
-    set(`myCurrentPVPWins_${i}`, 7);
-    set(`myCurrentPVPLosses_${i}`, 7);
+    set(`myCurrentPVPWins_${i}`, 0);
+    set(`myCurrentPVPLosses_${i}`, 0);
     set(`myCurrentPVPMini_${i}`, activeMinisSorted[i]);
   });
 
@@ -208,7 +209,7 @@ export function printStats(): void {
 }
 
 export function printStrategiesEstimates(): void {
-  const fightRecords = getFightRecords();
+  const fightRecords = getMutatedFightRecords();
   const t = Math.max(1, sumNumbers(fightRecords.map(([wins, losses]) => wins + losses)));
   const logConst = 2 * Math.log(t);
   // const Exp3Ls = pvpIDs.map((i) => get(`myCurrentPVPMiniExp3Weight_${i}`, 1.0));

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -121,7 +121,7 @@ export function breakStone(): void {
 export function updateSeason(): void {
   const currentSeason = Array.from(
     visitUrl("peevpee.php?place=rules").match(
-      RegExp(/<b>Current Season: <\/b>(.*?)( \\(Post-Season\\))?<br \/>/)
+      RegExp(/<b>Current Season: <\/b>(.*?)( \(Post-Season\))?<br \/>/)
     ) ?? ["", "0"]
   )[1];
 
@@ -139,7 +139,6 @@ export function updateSeason(): void {
   pvpIDs.forEach((i) => {
     set(`myCurrentPVPWins_${i}`, 7);
     set(`myCurrentPVPLosses_${i}`, 7);
-    set(`myCurrentPVPMini_${i}`, "");
     set(`myCurrentPVPMini_${i}`, activeMinisSorted[i]);
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ export function main(argstring = ""): void {
         break;
       }
 
-      if (parseResult) {
+      if (parseResult(result)) {
         set("todaysPVPWins", (todaysWins += 1));
         set("totalSeasonPVPWins", (seasonWins += 1));
       } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,9 @@ export function main(argstring = ""): void {
   updateWinRate();
 
   let todaysWins = get("todaysPVPWins", 0),
-    todaysLosses = get("todaysPVPLosses", 0);
+    todaysLosses = get("todaysPVPLosses", 0),
+    seasonWins = get("totalSeasonPVPWins", 0),
+    seasonLosses = get("totalSeasonPVPLosses", 0);
 
   if (pvpAttacksLeft() > 0) {
     initializeSortedPvpIDs();
@@ -53,9 +55,14 @@ export function main(argstring = ""): void {
         print("Could not find anyone to fight!", "red");
         break;
       }
-      parseResult(result)
-        ? set("todaysPVPWins", (todaysWins += 1))
-        : set("todaysPVPLosses", (todaysLosses += 1));
+
+      if (parseResult) {
+        set("todaysPVPWins", (todaysWins += 1));
+        set("totalSeasonPVPWins", (seasonWins += 1));
+      } else {
+        set("todaysPVPLosses", (todaysLosses += 1));
+        set("totalSeasonPVPLosses", (seasonLosses += 1));
+      }
     }
     set("logPreferenceChange", prefChangeSettings);
   } else {

--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -5,7 +5,7 @@ import {
   activeMinisSorted,
   // getExp3IXProbabilities,
   // getExp3Probabilities,
-  getFightRecords,
+  getMutatedFightRecords,
   pvpIDs,
   // sampleProbabilitiesIdx,
   sortedPvpIDs,
@@ -15,7 +15,7 @@ import { args } from "./args";
 
 export function UCB(): number {
   if (args.debug) print("Using UCB strategy", "blue");
-  const fightRecords = getFightRecords();
+  const fightRecords = getMutatedFightRecords();
   const t = Math.max(1, sumNumbers(fightRecords.map(([wins, losses]) => wins + losses)));
   const logConst = 2 * Math.log(t);
   const payoffs = pvpIDs.map((i) => {
@@ -30,7 +30,7 @@ export function UCB(): number {
 
 export function gaussianThompson(): number {
   if (args.debug) print("Using Gaussian Thompson strategy", "blue");
-  const fightRecords = getFightRecords();
+  const fightRecords = getMutatedFightRecords();
   const payoffs = pvpIDs.map((i) => {
     const [wins, losses] = fightRecords[i];
     const n = wins + losses;
@@ -43,7 +43,7 @@ export function gaussianThompson(): number {
 
 export function bernoulliThompson(): number {
   if (args.debug) print("Using Bernoulli Thompson strategy", "blue");
-  const fightRecords = getFightRecords();
+  const fightRecords = getMutatedFightRecords();
   const payoffs = pvpIDs.map((i) => {
     const [wins, losses] = fightRecords[i];
     const payoff = sampleBeta(wins, losses);
@@ -55,7 +55,7 @@ export function bernoulliThompson(): number {
 
 export function epsilonGreedy(): number {
   if (args.debug) print("Using Epsilon Greedy strategy", "blue");
-  const fightRecords = getFightRecords();
+  const fightRecords = getMutatedFightRecords();
   const t = Math.max(1, sumNumbers(fightRecords.map(([wins, losses]) => wins + losses)));
   const payoffs = pvpIDs.map((i) => {
     const [wins, losses] = fightRecords[i];


### PR DESCRIPTION
* Fixes regex that reset stats on post-season
* Fixes unneeded property change
* Fixes wins/losses starting at 7, and increases the number elsewhere which resolves the underlying issue
* Added season win/loss incrementing

This is marked as a draft as I was unable to test due to issues trying to setup an environment to build.
This addresses issue #8 

Will test this at some later point, this PR is available for anyone who wants to take the time to review & test it.