### PR TITLE
Allow win/loss messages, allow challenging harder opponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ git checkout https://github.com/Pantocyclus/PVP_MAB.git release
 
 To run the script, simply type `PVP_MAB` into the CLI. It accepts arguments (loot|fame|flowers) to set the PVP attack type, and (UCB|bernoulliThompson|gaussianThompson|epsilonGreedy) to set the strategy (i.e. `PVP_MAB target=fame strategy=UCB`), and defaults to fame (HC)/loot (otherwise) for attack and bernoulliThompson for strategy.
 
+It's not advised to use the flag `ranked` to fight tougher opponents for more fame gain and +1 swagger, unless you're very confident.
+
+You can control the pvp win/loss messages by setting the KoLMafia properties `defaultFlowerWinMessage` and `defaultFlowerLossMessage`.
+These have no message by default. Set them by running `set pref_name=message` in gCLI, eg:
+`set defaultFlowerLossMessage=I knew 'ranked' wasn't a good idea!`
+`set defaultFlowerWinMessage=I win so many fights when I don't use 'ranked'!`
+
 ## Why do I need a Multi-Armed Bandit PVP script?
 
 [Flogger](https://github.com/DamianDominoDavis/kol-flogger) is a good way of keeping track of your PVP stats, which then provides you with the necessary information to determine which is your best mini. However, consider the following scenarios/stats.

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,6 +1,7 @@
 import { Args } from "grimoire-kolmafia";
 import { canInteract } from "kolmafia";
 import { Strategy } from "./lib";
+import { get } from "libram";
 
 type PvpTarget = "fame" | "loot" | "flowers";
 
@@ -36,6 +37,20 @@ export const args = Args.create("pvp_mab", "A multi-armed bandit script for pvp"
     (x) => x as Strategy,
     "multi-armed bandit strategy"
   ),
+  winMessage: Args.string({
+    help: "Message to show on fight win, defaults to 'defaultFlowerWinMessage'",
+    // The default is an empty string
+    default: get("defaultFlowerWinMessage"),
+  }),
+  lossMessage: Args.string({
+    help: "Message to show on fight loss, defaults to 'defaultFlowerLossMessage'",
+    // The default is an empty string
+    default: get("defaultFlowerLossMessage"),
+  }),
+  ranked: Args.flag({
+    help: "Fight random tougher opponents for +1 swagger and increased fame gain",
+    default: false,
+  }),
   no_optimize: Args.flag({
     help: "Skip the uberpvpoptimizer step",
     default: false,

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,7 +1,6 @@
 import { Args } from "grimoire-kolmafia";
 import { canInteract } from "kolmafia";
 import { Strategy } from "./lib";
-import { get } from "libram";
 
 type PvpTarget = "fame" | "loot" | "flowers";
 
@@ -37,16 +36,6 @@ export const args = Args.create("pvp_mab", "A multi-armed bandit script for pvp"
     (x) => x as Strategy,
     "multi-armed bandit strategy"
   ),
-  winMessage: Args.string({
-    help: "Message to show on fight win, defaults to 'defaultFlowerWinMessage'",
-    // The default is an empty string
-    default: get("defaultFlowerWinMessage"),
-  }),
-  lossMessage: Args.string({
-    help: "Message to show on fight loss, defaults to 'defaultFlowerLossMessage'",
-    // The default is an empty string
-    default: get("defaultFlowerLossMessage"),
-  }),
   ranked: Args.flag({
     help: "Fight random tougher opponents for +1 swagger and increased fame gain",
     default: false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -8,6 +8,7 @@ import {
   itemAmount,
   print,
   todayToString,
+  urlEncode,
   use,
   visitUrl,
   xpath,
@@ -186,7 +187,13 @@ export function pvpAttack(attackType: string): string {
   const beforePVPScriptName = get("beforePVPScript");
   if (beforePVPScriptName.length > 0) cliExecute(beforePVPScriptName);
   return visitUrl(
-    `peevpee.php?action=fight&place=fight&ranked=1&stance=${pvpChoice}&attacktype=${attackType}&pwd`
+    `peevpee.php?action=fight&place=fight&ranked=${
+      args.ranked ? 2 : 1
+    }&stance=${pvpChoice}&attacktype=${attackType}&losemessage=${urlEncode(
+      args.lossMessage
+    )}&winmessage=${urlEncode(args.winMessage)}&pwd`,
+    true,
+    true
   );
 }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -190,8 +190,8 @@ export function pvpAttack(attackType: string): string {
     `peevpee.php?action=fight&place=fight&ranked=${
       args.ranked ? 2 : 1
     }&stance=${pvpChoice}&attacktype=${attackType}&losemessage=${urlEncode(
-      args.lossMessage
-    )}&winmessage=${urlEncode(args.winMessage)}&pwd`,
+      get(`defaultFlowerLossMessage`)
+    )}&winmessage=${urlEncode(get(`defaultFlowerWinMessage`))}&pwd`,
     true,
     true
   );


### PR DESCRIPTION
The win/loss messages are not autofilled by kol and must be sent along with the attack.

We don't inherit the mafia property names for messages, and instead provide an override for two reasons.
1. better control
2. mafia's naming is too obscure

As for the "ranked" option, useful if you are dominating the pvp season.